### PR TITLE
Implement standard error trait for gp::Error

### DIFF
--- a/src/gp.rs
+++ b/src/gp.rs
@@ -42,6 +42,9 @@ impl Error {
     }
 }
 
+impl std::error::Error for Error {
+}
+
 impl std::fmt::Display for Error {
     fn fmt(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(formatter, "{}", self.message)


### PR DESCRIPTION
Implement the standard Error trait for gp::Error so that people can use the ? operator in functions returning Result<_,Box<dyn Error>> for example.