### PR TITLE
Re-exported two enums as public named ErrorTleWhat and ErrorTleLine

### DIFF
--- a/src/gp.rs
+++ b/src/gp.rs
@@ -694,7 +694,7 @@ impl Elements {
                         end: 32,
                     })?;
                 let seconds = day.fract() * (24.0 * 60.0 * 60.0);
-                chrono::NaiveDate::from_yo(
+                chrono::NaiveDate::from_yo_opt(
                     match line1[18..20].parse::<u8>().map_err(|_| Error::Tle {
                         what: ErrorTleWhat::ExpectedFloat,
                         line: ErrorTleLine::Line1,
@@ -706,10 +706,14 @@ impl Elements {
                     },
                     day as u32,
                 )
-                .and_time(chrono::NaiveTime::from_num_seconds_from_midnight(
-                    seconds as u32,
-                    (seconds.fract() * 1e9).round() as u32,
-                ))
+                .expect("Failed to make a NaiveDate")
+                .and_time(
+                    chrono::NaiveTime::from_num_seconds_from_midnight_opt(
+                        seconds as u32,
+                        (seconds.fract() * 1e9).round() as u32,
+                    )
+                    .expect("Failed to make NaiveDate from midnight opt"),
+                )
             },
             mean_motion_dot: line1[33..43]
                 .trim_ascii_start_polyfill()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,6 @@
 //!
 
 #![cfg_attr(docsrs, feature(doc_cfg))]
-
 #![cfg_attr(not(feature = "std"), no_std)]
 
 #[cfg(not(any(feature = "std", feature = "libm")))]
@@ -59,6 +58,8 @@ pub use deep_space::ResonanceState;
 pub use gp::Classification;
 pub use gp::Elements;
 pub use gp::Error;
+pub use gp::ErrorTleLine;
+pub use gp::ErrorTleWhat;
 pub use gp::Result;
 pub use model::afspc_epoch_to_sidereal_time;
 pub use model::iau_epoch_to_sidereal_time;


### PR DESCRIPTION
- [x] Marked two enums `ErrorTleWhat` and `ErrorTleLine` as public as they were being used as public but not exported as public for checking in an error
- [x] Switched `NaiveDate` construction from `from_yo` to `from_yo_opt` as suggested by the compiler.