### PR TITLE
refactor(lib): replace manual clamp with f32::clamp

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -698,13 +698,7 @@ impl Constants {
             }
 
             // (E + ω)ᵢ₊₁ = (E + ω)ᵢ + Δ(E + ω)ᵢ|[-0.95, 0.95]
-            ew += if delta < -0.95 {
-                -0.95
-            } else if delta > 0.95 {
-                0.95
-            } else {
-                delta
-            };
+            ew += delta.clamp(-0.95, 0.95);
         }
 
         // p₃₉ = aₓₙ² + aᵧₙ²


### PR DESCRIPTION
This should fix the [latest CI failure](https://github.com/neuromorphicsystems/sgp4/actions/runs/12800756994).

- Simplify the code by using the built-in f32::clamp method
- Improve readability and maintainability