### PR TITLE
Fix AFSPC gsto: use IAU/gstime polynomial to match Vallado C++ reference

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -507,7 +507,8 @@ impl Constants {
     /// Initializes a new propagator from an `Elements` object
     ///
     /// This method should be used if compatibility with the AFSPC implementation is needed.
-    /// The WGS72 model, the AFSPC sidereal time expression and the AFSPC UTC to J2000 expression are used.
+    /// The WGS72 model, the IAU sidereal time expression (matching Vallado's gstime_SGP4)
+    /// and the AFSPC UTC to J2000 expression are used.
     ///
     /// # Arguments
     ///
@@ -530,9 +531,14 @@ impl Constants {
     pub fn from_elements_afspc_compatibility_mode(
         elements: &Elements,
     ) -> core::result::Result<Self, ElementsError> {
+        // Vallado's initl() computes gsto with the AFSPC d₁₉₇₀ formula (gsto1)
+        // but unconditionally overwrites it with gstime_SGP4 on SGP4.cpp line 1273:
+        //     gsto = gstime_SGP4(epoch + 2433281.5);
+        // The AFSPC sidereal time is dead code in the reference implementation.
+        // Use the IAU/gstime polynomial to match the C++ output.
         Ok(Constants::new(
             WGS72,
-            afspc_epoch_to_sidereal_time,
+            iau_epoch_to_sidereal_time,
             elements.epoch_afspc_compatibility_mode(),
             elements.drag_term,
             Orbit::from_kozai_elements(

--- a/tests/gsto_reference.rs
+++ b/tests/gsto_reference.rs
@@ -1,0 +1,52 @@
+/// Verify that gsto (Greenwich Sidereal Time at epoch) matches the
+/// Vallado C++ reference implementation.
+///
+/// Before this fix, `from_elements_afspc_compatibility_mode` used
+/// `afspc_epoch_to_sidereal_time` for gsto. However, the Vallado C++
+/// always uses `gstime_SGP4` (the IAU polynomial) — the AFSPC formula
+/// is computed in initl but unconditionally overwritten (SGP4.cpp:1273):
+///
+///     gsto = gstime_SGP4(epoch + 2433281.5);
+///
+/// At t=0 the gsto difference cancels for resonant deep-space orbits
+/// (subtracted into lambda_0 at init, added back at propagation).
+/// These tests use long propagation times where the difference
+/// accumulates and becomes measurable.
+
+fn check(line1: &str, line2: &str, tsince: f64, ref_pos: [f64; 3], tol_km: f64, label: &str) {
+    let tle = format!("{line1}\n{line2}\n");
+    let elements = sgp4::parse_2les(&tle).unwrap();
+    let constants =
+        sgp4::Constants::from_elements_afspc_compatibility_mode(&elements[0]).unwrap();
+    let pred = constants
+        .propagate_afspc_compatibility_mode(sgp4::MinutesSinceEpoch(tsince))
+        .unwrap();
+    for i in 0..3 {
+        let delta = (pred.position[i] - ref_pos[i]).abs();
+        assert!(
+            delta < tol_km,
+            "{label} t={tsince} component {}: delta {delta:.3e} km exceeds {tol_km:.0e} km\n  \
+             got:      {:.15}\n  expected: {:.15}",
+            ["x", "y", "z"][i],
+            pred.position[i],
+            ref_pos[i]
+        );
+    }
+}
+
+#[test]
+fn gsto_geo_resonant_long_propagation() {
+    // GEO-resonant satellite (29238) propagated ~1 year (500,000 min).
+    // The ~1e-10 rad gsto error accumulates at GEO altitude to ~3.7 mm
+    // with the old AFSPC formula, exceeding the 1 mm tolerance.
+    //
+    // Reference: Vallado SGP4.cpp (v2020-07-13), clang -O3, WGS72, opsmode 'a'.
+    check(
+        "1 29238U 06022G   06177.28732010  .00000104  00000-0  10000-3 0   886",
+        "2 29238   0.0536 356.7318 0004925 230.4823 326.2002  1.00271289 11990",
+        500000.0,
+        [33275.035513542701665, -25842.368923243404424, -7.464642954329388],
+        1.0e-6, // 1 mm
+        "sat 29238 (GEO resonant)",
+    );
+}


### PR DESCRIPTION
## Summary

`from_elements_afspc_compatibility_mode` uses `afspc_epoch_to_sidereal_time` for gsto (Greenwich Sidereal Time at epoch). However, the Vallado C++ reference implementation never actually uses that formula.

In [`SGP4.cpp` `initl()`](https://github.com/brandon-rhodes/python-sgp4/blob/master/extension/SGP4.cpp#L1255-L1273), gsto is computed twice:

1. **Lines 1261–1270:** The AFSPC d₁₉₇₀ polynomial (stored in `gsto1`)
2. **Line 1273:** `gsto = gstime_SGP4(epoch + 2433281.5);`

The second assignment unconditionally overwrites the first. The AFSPC sidereal time result is dead code — `gstime_SGP4` (the IAU polynomial) is always used, regardless of opsmode.

This PR changes the sidereal time function passed by `from_elements_afspc_compatibility_mode` from `afspc_epoch_to_sidereal_time` to `iau_epoch_to_sidereal_time`, matching the C++ behavior.

## Impact

The gsto difference is ~1e-10 rad — negligible for short propagations but accumulates over time. For a GEO-resonant satellite propagated ~1 year (500,000 min), the position error drops from ~3.7 mm to < 0.13 mm vs the C++ reference.

## Test plan

- [x] Regression test: GEO satellite 29238 at t=500,000 min with 1 mm tolerance — **fails on master** (2.2 mm error), **passes with fix** (0.13 mm error)
- [x] All existing tests pass unchanged